### PR TITLE
Added admin column that displays a single post's template name

### DIFF
--- a/includes/today-utilities-admin.php
+++ b/includes/today-utilities-admin.php
@@ -1,0 +1,39 @@
+<?php
+/**
+ * Updates to the WordPress admin interface.
+ */
+
+/**
+ * Defines new columns in the WordPress admin when viewing
+ * all posts or searching for posts.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ */
+function tu_custom_post_columns( $columns ) {
+    $columns['template'] = 'Template';
+    return $columns;
+}
+
+add_filter( 'manage_post_posts_columns', 'tu_custom_post_columns' );
+
+
+/**
+ * Defines content to display in custom columns for posts
+ * in the WordPress admin.
+ *
+ * @since 1.0.0
+ * @author Jo Dickson
+ */
+function tu_custom_post_columns_content( $column_name, $post_id ) {
+    switch ( $column_name ) {
+		case 'template':
+			$all_templates = get_page_templates( null, 'post' );
+			$template_slug = get_page_template_slug( $post_id );
+			$template_name = $template_slug ? array_search( $template_slug, $all_templates ) : 'Default';
+			echo $template_name;
+			break;
+    }
+}
+
+add_action( 'manage_post_posts_custom_column', 'tu_custom_post_columns_content', 10, 2 );

--- a/today-utilities.php
+++ b/today-utilities.php
@@ -11,3 +11,5 @@ GitHub Plugin URI: UCF/Today-Utilities
 if ( ! defined( 'WPINC' ) ) {
     die;
 }
+
+require_once 'includes/today-utilities-admin.php';


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Makes it easier to distinguish single-column posts from two-column posts when viewing lists of posts in the WordPress Admin.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.  Note that stories that still have old post template names assigned to them won't display a template name yet; this will be fixed once we run a content migration that updates that metadata.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
