### PR TITLE
Added GMUCF api from the old today theme

### DIFF
--- a/api/today-custom-post-api.php
+++ b/api/today-custom-post-api.php
@@ -1,0 +1,195 @@
+<?php
+/**
+ * All custom wp-json API endpoints should be defined
+ * within this file.
+ */
+if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
+	class UCF_Today_Custom_API extends WP_REST_Controller {
+		/**
+		 * Registers the rest routes for the ucf_news api
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 */
+		public static function register_rest_routes() {
+			$root    = 'ucf-news';
+			$version = 'v1';
+
+			register_rest_route( "{$root}/{$version}", "/external-stories", array(
+				array(
+					'methods'              => WP_REST_Server::READABLE,
+					'callback'             => array( 'UCF_Today_Custom_API', 'get_external_stories' ),
+					'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' ),
+					'args'                 => array( 'UCF_Today_Custom_API', 'get_external_story_args' )
+				)
+			) );
+
+			register_rest_route( "{$root}/{$version}", "/gmucf-email-options", array(
+				array(
+					'methods'              => WP_REST_Server::READABLE,
+					'callback'             => array( 'UCF_Today_Custom_API', 'get_gmucf_email_options' ),
+					'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' )
+				)
+			) );
+		}
+
+		/**
+		 * Gets the external stories
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 * @param WP_REST_Request $request | Contains GET params
+		 * @return WP_REST_Response
+		 */
+		public static function get_external_stories( $request ) {
+			// Handle args and set defaults
+			$search     = $request['search'];
+			$source     = $request['source'];
+			$limit      = $request['limit'] ? $request['limit'] : 10;
+			$offset     = $request['offset'] ? $request['offset'] : 0;
+			$categories = $request['categories'];
+
+			// Initialize out return value
+			$retval = array();
+
+			// Initialize and set defaults on argument array
+			$args = array(
+				'post_type'      => 'externalstory',
+				'posts_per_page' => $limit,
+				'offset'         => $offset
+			);
+
+			// Add search if it's set
+			if ( $search ) {
+				$args['s'] = $search;
+			}
+
+			// Add source meta query if it's set
+			if ( $source ) {
+				$sources = explode( ',', $source );
+
+				$args['meta_query'] = array();
+
+				foreach ( $sources as $source ) {
+					$args['meta_query'][] = array(
+						'key'   => 'externalstory_source',
+						'value' => $source
+					);
+				}
+
+				if ( count( $args['meta_query'] ) > 1 ) {
+					$args['meta_query']['relation'] = 'OR';
+				}
+			}
+
+			if ( $categories ) {
+				$args['category_name'] = $categories;
+			}
+
+			$posts = get_posts( $args );
+
+			foreach( $posts as $post ) {
+				$data     = self::prepare_external_story_for_response( $post, $request );
+				$retval[] = $data;
+			}
+
+			return new WP_REST_Response( $retval, 200 );
+		}
+
+		/**
+		 * Formats the external story for response
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 * @param WP_Post $post The post
+		 * @param WP_REST_Request $request The request object
+		 * @return array A serializable array.
+		 */
+		private static function prepare_external_story_for_response( $post, $request ) {
+
+			$terms = wp_get_post_terms( $post->ID, 'sources' );
+			$field = ( !empty( $terms ) ) ? get_field( 'news_source_image', $terms[0] ) : null;
+			$source_image = ( !empty( $field ) ) ? $field['url'] : null;
+			$source_name = wp_get_post_terms( $post->ID, 'sources' );
+
+			// Prepare the return value format
+			$retval = array(
+				'title'        => '',
+				'link_text'    => '',
+				'description'  => '',
+				'url'          => '',
+				'source'       => '',
+				'source_name'  => '',
+				'source_image' => '',
+				'publish_date' => '',
+				'categories'   => array()
+			);
+
+			$retval['title']        = $post->post_title;
+			$retval['link_text']    = get_post_meta( $post->ID, 'externalstory_text', true );
+			$retval['description']  = get_post_meta( $post->ID, 'externalstory_description', true );
+			$retval['url']          = get_post_meta( $post->ID, 'externalstory_url', true );
+			$retval['source']       = get_post_meta( $post->ID, 'externalstory_source', true );
+			$retval['source_name']  = ( !empty( $source_name ) ) ? $source_name[0]->name : null;
+			$retval['source_image'] = $source_image;
+			$retval['publish_date'] = $post->post_date;
+			$retval['categories']   = wp_get_post_categories( $post->ID, array( 'fields' => 'names' ) );
+
+			return $retval;
+		}
+
+		/**
+		 * Gets the default permissions
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 */
+		public static function get_permissions() {
+			return true;
+		}
+
+		/**
+		 * Gets the allowable args for external stories
+		 * @since 2.8.0
+		 * @author Jim Barnes
+		 */
+		public static function get_external_story_args() {
+			return array(
+				array(
+					'search' => array(
+						'default'           => false,
+						'sanitize_callback' => 'sanitize_text_field'
+					),
+					'source' => array(
+						'default'           => false,
+						'sanitize_callback' => 'sanitize_text_field'
+					),
+					'limit' => array(
+						'default'           => 10,
+						'sanitize_callback' => 'absint'
+					),
+					'offset' => array(
+						'default'           => 0,
+						'sanitize_callback' => 'absint'
+					),
+					'categories' => array(
+						'default'           => false,
+						'sanitize_callback' => 'sanitize_text_field'
+					)
+				)
+			);
+		}
+
+		/**
+		 * Gets the GMUCF email options
+		 * @since 2.9.0
+		 * @author Cadie
+		 * @param WP_REST_Request $request | Contains GET params
+		 * @return WP_REST_Response
+		 */
+		public static function get_gmucf_email_options( $request ) {
+			$retval = get_fields( 'gmucf_options' );
+
+			$gmucf_content_rows            = $retval['gmucf_email_content'];
+			$retval['gmucf_email_content'] = gmucf_stories_default_values( $gmucf_content_rows );
+
+			return new WP_REST_Response( $retval, 200 );
+		}
+	}
+}

--- a/api/today-custom-post-api.php
+++ b/api/today-custom-post-api.php
@@ -7,7 +7,7 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 	class UCF_Today_Custom_API extends WP_REST_Controller {
 		/**
 		 * Registers the rest routes for the ucf_news api
-		 * @since 2.8.0
+		 * @since 1.0.0
 		 * @author Jim Barnes
 		 */
 		public static function register_rest_routes() {
@@ -34,7 +34,7 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 
 		/**
 		 * Gets the external stories
-		 * @since 2.8.0
+		 * @since 1.0.0
 		 * @author Jim Barnes
 		 * @param WP_REST_Request $request | Contains GET params
 		 * @return WP_REST_Response
@@ -96,7 +96,7 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 
 		/**
 		 * Formats the external story for response
-		 * @since 2.8.0
+		 * @since 1.0.0
 		 * @author Jim Barnes
 		 * @param WP_Post $post The post
 		 * @param WP_REST_Request $request The request object
@@ -137,7 +137,7 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 
 		/**
 		 * Gets the default permissions
-		 * @since 2.8.0
+		 * @since 1.0.0
 		 * @author Jim Barnes
 		 */
 		public static function get_permissions() {
@@ -146,7 +146,7 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 
 		/**
 		 * Gets the allowable args for external stories
-		 * @since 2.8.0
+		 * @since 1.0.0
 		 * @author Jim Barnes
 		 */
 		public static function get_external_story_args() {
@@ -178,7 +178,7 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 
 		/**
 		 * Gets the GMUCF email options
-		 * @since 2.9.0
+		 * @since 1.0.0
 		 * @author Cadie
 		 * @param WP_REST_Request $request | Contains GET params
 		 * @return WP_REST_Response

--- a/includes/today-gmucf-options.php
+++ b/includes/today-gmucf-options.php
@@ -1,0 +1,82 @@
+<?php
+/**
+ * Functions for adding and supporting the
+ * GMUCF Options Page
+ */
+function tu_add_gmucf_options_page() {
+	if ( function_exists( 'acf_add_options_page' ) ) {
+		acf_add_options_page( array(
+			'page_title' 	  => 'GMUCF Email',
+			'post_id'         => 'gmucf_options',
+			'menu_title'	  => 'GMUCF Email',
+			'menu_slug' 	  => 'gmucf-email',
+			'capability'	  => 'administrator',
+			'icon_url'        => 'dashicons-email-alt',
+			'redirect'        => false,
+			'updated_message' => 'GMUCF Options Updated'
+		) );
+	}
+}
+
+
+/**
+ * Sets the default values for each stories' image, title and
+ * description for use in the GMUCF Today emails
+ * @since 2.9.0
+ * @author Cadie Brown
+ * @param Array $story | single array with story data
+ * @return Array
+ */
+function gmucf_replace_story_default_values( $story ) {
+	$post_id = $story['gmucf_story'];
+	if ( ! $story['gmucf_story_image'] ) {
+		$story['gmucf_story_image'] = get_the_post_thumbnail_url( $post_id, 'gmucf_top_story' );
+	} else {
+		$story['gmucf_story_image'] = $story['gmucf_story_image']['sizes']['gmucf_top_story'];
+	}
+	if ( ! $story['gmucf_story_title'] ) {
+		$story['gmucf_story_title'] = get_the_title( $post_id );
+	}
+	if ( ! $story['gmucf_story_description'] ) {
+		$story['gmucf_story_description'] = get_post_meta( $post_id, 'promo', true );
+	}
+	$story['gmucf_story_permalink'] = get_permalink( $post_id );
+	if ( $story['acf_fc_layout'] ) {
+		$story['gmucf_layout'] = $story['acf_fc_layout'];
+		unset( $story['acf_fc_layout'] );
+	}
+	unset( $story['gmucf_story'] );
+	return $story;
+}
+
+/**
+ * Sets the default values depending on what kind
+ * of layout is being used
+ * @since 2.9.0
+ * @author Cadie Brown
+ * @param Array $stories | gmucf_email_content array from ACF GMUCF Options Page
+ * @return Array
+ */
+function gmucf_stories_default_values( $stories ) {
+	foreach ( $stories as $story ) {
+		if ( $story['acf_fc_layout'] === 'gmucf_top_story' ) {
+			$retval[] = gmucf_replace_story_default_values( $story );
+		} elseif ( $story['acf_fc_layout'] === 'gmucf_featured_stories_row' ) {
+			$story['gmucf_layout']               = $story['acf_fc_layout'];
+			$story['gmucf_featured_story_row'][] = gmucf_replace_story_default_values( $story['gmucf_left_featured_story'] );
+			$story['gmucf_featured_story_row'][] = gmucf_replace_story_default_values( $story['gmucf_right_featured_story'] );
+			unset( $story['acf_fc_layout'] );
+			unset( $story['gmucf_left_featured_story'] );
+			unset( $story['gmucf_right_featured_story'] );
+			$retval[] = $story;
+		} elseif ( $story['acf_fc_layout'] === 'gmucf_spotlight' ) {
+			$story['gmucf_spotlight_image'] = $story['gmucf_spotlight_image']['sizes']['gmucf_top_story'];
+			$story['gmucf_layout']          = $story['acf_fc_layout'];
+			unset( $story['acf_fc_layout'] );
+			$retval[] = $story;
+		} else {
+			$retval[] = $story;
+		}
+	}
+	return $retval;
+}

--- a/today-utilities.php
+++ b/today-utilities.php
@@ -13,3 +13,17 @@ if ( ! defined( 'WPINC' ) ) {
 }
 
 require_once 'includes/today-utilities-admin.php';
+require_once 'includes/today-gmucf-options.php';
+
+require_once 'api/today-custom-post-api.php';
+
+if ( ! function_exists( 'tu_init' ) ) {
+	function tu_init() {
+		add_action( 'rest_api_init', array( 'UCF_Today_Custom_API', 'register_rest_routes' ), 10, 0 );
+
+		// Add options pages.
+		add_action( 'init', 'tu_add_gmucf_options_page' );
+	}
+
+	add_action( 'plugins_loaded', 'tu_init', 10, 0 );
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Creates a custom options page for GMUCF Feed Options and provides a custom API of those option values.

**Motivation and Context**
This is code ported over from the current Today-Bootstrap theme.

**How Has This Been Tested?**
Change can be seen in the development environment.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
