### PR TITLE
Added missing support for category_slugs and tag_slugs params in REST API results for posts

### DIFF
--- a/includes/today-feeds.php
+++ b/includes/today-feeds.php
@@ -83,3 +83,44 @@ function tu_add_author_byline_to_post_feed() {
 }
 
 add_action( 'rest_api_init', 'tu_add_author_byline_to_post_feed' );
+
+
+/**
+ * Adds support for "category_slugs" and "tag_slugs" params
+ * in REST API results for posts.
+ *
+ * Ported over from Today-Bootstrap
+ *
+ * @since 1.0.3
+ */
+function tu_add_tax_query_to_posts_endpoint( $args, $request ) {
+	$params = $request->get_params();
+
+	$tax_query = array();
+
+	if ( isset( $params['category_slugs'] ) ) {
+		$tax_query[] =
+			array(
+				'taxonomy' => 'category',
+				'field'    => 'slug',
+				'terms'    => $params['category_slugs']
+			);
+	}
+
+	if ( isset( $params['tag_slugs'] ) ) {
+		$tax_query[] =
+			array(
+				'taxonomy' => 'post_tag',
+				'field'    => 'slug',
+				'terms'    => $params['tag_slugs']
+			);
+	}
+
+	if ( count( $tax_query ) > 0 ) {
+		$args['tax_query'] = $tax_query;
+	}
+
+	return $args;
+}
+
+add_action( 'rest_post_query', 'tu_add_tax_query_to_posts_endpoint', 2, 10 );


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Required for support with the UCF News plugin filtering by category/tag.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in QA.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
