### PR TITLE
Added Juxtapose oEmbed support

### DIFF
--- a/includes/today-utilities-admin.php
+++ b/includes/today-utilities-admin.php
@@ -199,3 +199,12 @@ function tu_handle_upload_prefilter( $file ) {
 }
 
 add_filter( 'wp_handle_upload_prefilter', 'tu_handle_upload_prefilter', 10, 1 );
+
+
+/**
+ * Adds oEmbed support for Juxtapose.
+ *
+ * @since v1.0.3
+ * @author Jo Dickson
+ */
+wp_oembed_add_provider( 'https://cdn.knightlab.com/libs/juxtapose/latest/embed/*', 'https://oembed.knightlab.com/juxtapose/' );


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Registers Juxtapose as a valid oEmbed provider in WordPress, allowing oEmbed-friendly URLs to be pasted into the WYSIWYG editor on their own line, similarly to YouTube embeds.

See also: https://github.com/UCF/Today-Child-Theme/pull/79, which adds updates to the generated embed markup to improve responsiveness and sizing.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Suggested by the content team.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewable in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
