### PR TITLE
Added primary category and tag fields to posts endpoints

### DIFF
--- a/includes/today-feeds.php
+++ b/includes/today-feeds.php
@@ -45,6 +45,96 @@ add_action( 'rest_api_init', 'tu_add_image_to_post_feed' );
 
 
 /**
+ * REST API callback function that returns a post's
+ * primary category ID (Yoast plugin feature) using logic from
+ * the Today Child Theme.
+ *
+ * @since 1.0.10
+ * @author Jo Dickson
+ * @param array $object Array of single feed object data
+ * @param string $field_name Name of the current field (in this case, 'primary_category')
+ * @param object $request WP_REST_Request object; contains details about the current request
+ * @return mixed WP_Term object, or null on failure
+ */
+function tu_post_get_primary_category( $object, $field_name, $request ) {
+	$primary = null;
+
+	if ( function_exists( 'today_get_primary_category' ) ) {
+		$post = get_post( $object['id'] );
+		if ( $cat = today_get_primary_category( $post ) ) {
+			$primary = $cat->term_id;
+		}
+	}
+
+	return $primary;
+}
+
+
+/**
+ * Registers the custom "primary_category" field in REST API
+ * results for posts.
+ *
+ * @since 1.0.10
+ * @author Jo Dickson
+ */
+function tu_add_primary_cat_to_post_feed() {
+	register_rest_field( 'post', 'primary_category',
+		array(
+			'get_callback' => 'tu_post_get_primary_category',
+			'schema'       => null,
+		)
+	);
+}
+
+add_action( 'rest_api_init', 'tu_add_primary_cat_to_post_feed' );
+
+
+/**
+ * REST API callback function that returns a post's
+ * primary tag ID (ACF plugin feature) using logic from
+ * the Today Child Theme.
+ *
+ * @since 1.0.10
+ * @author Jo Dickson
+ * @param array $object Array of single feed object data
+ * @param string $field_name Name of the current field (in this case, 'primary_tag')
+ * @param object $request WP_REST_Request object; contains details about the current request
+ * @return mixed WP_Term object, or null on failure
+ */
+function tu_post_get_primary_tag( $object, $field_name, $request ) {
+	$primary = null;
+
+	if ( function_exists( 'today_get_primary_tag' ) ) {
+		$post = get_post( $object['id'] );
+		if ( $tag = today_get_primary_tag( $post ) ) {
+			$primary = $tag->term_id;
+		}
+	}
+
+	return $primary;
+}
+
+
+/**
+ * Registers the custom "primary_tag" field in REST API
+ * results for posts.
+ *
+ * @since 1.0.10
+ * @author Jo Dickson
+ */
+function tu_add_primary_tag_to_post_feed() {
+	register_rest_field( 'post', 'primary_tag',
+		array(
+			'get_callback' => 'tu_post_get_primary_tag',
+			'schema'       => null,
+		)
+	);
+}
+
+add_action( 'rest_api_init', 'tu_add_primary_tag_to_post_feed' );
+
+
+/**
  * REST API callback function that returns a post's author
  * name, using logic that mimics the Today Child Theme
  *


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Adds `primary_category` and `primary_tag` fields to post list endpoints (the main /wp/v2/posts/ endpoint, as well as the main-site-stories endpoint).

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Allows the UCF News plugin (or other applications digesting the REST API) to display our intended primary category and tag, instead of relying on the first available in the list of all terms.

Required to resolve https://github.com/UCF/UCF-News-Plugin/issues/42.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
