### PR TITLE
REST endpoint for Statement archives by year, author

### DIFF
--- a/api/today-custom-post-api.php
+++ b/api/today-custom-post-api.php
@@ -327,15 +327,14 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 
 			// Get links to vanilla Statements REST endpoint,
 			// filtered by authors assigned to at least one Statement:
-			$query = $wpdb->prepare(
+			$authors = $wpdb->get_results(
 				"SELECT t.term_id, t.name, t.slug from $wpdb->terms AS t
 				INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id
 				INNER JOIN $wpdb->term_relationships AS r ON r.term_taxonomy_id = tt.term_taxonomy_id
 				INNER JOIN $wpdb->posts AS p ON p.ID = r.object_id
 				WHERE p.post_type = 'ucf_statement' AND tt.taxonomy = 'tu_author'
 				GROUP BY t.term_id"
-			);
-			$authors = $wpdb->get_results( $query ) ?: array();
+			) ?: array();
 
 			if ( $authors ) {
 				array_walk( $authors, function( &$val, $key ) {

--- a/api/today-custom-post-api.php
+++ b/api/today-custom-post-api.php
@@ -3,6 +3,7 @@
  * All custom wp-json API endpoints should be defined
  * within this file.
  */
+
 if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 	class UCF_Today_Custom_API extends WP_REST_Controller {
 		/**
@@ -37,6 +38,18 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 					'callback'             => array( 'UCF_Today_Custom_API', 'get_mainsite_stories' ),
 					'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' ),
 					'args'                 => array( 'WP_REST_Post_Controller', 'get_collection_params' )
+				)
+			) );
+
+			// Need to register this filter to allow the statement-archives
+			// endpoint to properly retrieve list of years
+			add_filter( 'get_archives_link', 'tu_get_archives_link', 10, 6 );
+
+			register_rest_route( "{$root}/{$version}", "/statement-archives", array(
+				array(
+					'methods'              => WP_REST_Server::READABLE,
+					'callback'             => array( 'UCF_Today_Custom_API', 'get_statement_archives' ),
+					'permissions_callback' => array( 'UCF_Today_Custom_API', 'get_permissions' )
 				)
 			) );
 		}
@@ -275,5 +288,85 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 
 			return new WP_REST_Response( $retval[0], 200 );
 		}
+
+		/**
+		 * Returns a REST response that lists archives for
+		 * the Statement post type
+		 *
+		 * @since 1.1.0
+		 * @author Jo Dickson
+		 * @param WP_REST_Request $request Contains GET params
+		 * @return WP_REST_Response
+		 */
+		public static function get_statement_archives( $request ) {
+			global $wpdb;
+			$retval = array(
+				'all' => array(
+					'endpoint' => get_rest_url( null, '/wp/v2/statements' )
+				),
+				'years' => array(),
+				'authors' => array()
+			);
+
+			// Get links to vanilla Statements REST endpoint,
+			// filtered by year(s):
+			$years  = array_map( 'intval', array_filter( explode( ',', wp_get_archives( array(
+				'type'      => 'yearly',
+				'after'     => ',',
+				'echo'      => false,
+				'format'    => 'text', // custom format handling in `tu_get_archives_link()`
+				'post_type' => 'ucf_statement'
+			) ) ) ) );
+			foreach ( $years as $year ) {
+				// Strip timezone formatting; WordPress doesn't like
+				// it in before/after filters for whatever reason
+				$year_before = str_replace( '+00:00', '', date( 'c', mktime( -1, -1, -1, 13, 1, $year ) ) );
+				$year_after  = str_replace( '+00:00', '', date( 'c', mktime( 0, 0, 0, 1, 1, $year ) ) );
+				$retval['years'][] = array( 'year' => $year, 'endpoint' => get_rest_url( null, '/wp/v2/statements?before=' . $year_before . '&after=' . $year_after ) );
+			}
+
+			// Get links to vanilla Statements REST endpoint,
+			// filtered by authors assigned to at least one Statement:
+			$query = $wpdb->prepare(
+				"SELECT t.term_id, t.name, t.slug from $wpdb->terms AS t
+				INNER JOIN $wpdb->term_taxonomy AS tt ON t.term_id = tt.term_id
+				INNER JOIN $wpdb->term_relationships AS r ON r.term_taxonomy_id = tt.term_taxonomy_id
+				INNER JOIN $wpdb->posts AS p ON p.ID = r.object_id
+				WHERE p.post_type = 'ucf_statement' AND tt.taxonomy = 'tu_author'
+				GROUP BY t.term_id"
+			);
+			$authors = $wpdb->get_results( $query ) ?: array();
+
+			if ( $authors ) {
+				array_walk( $authors, function( &$val, $key ) {
+					$val->endpoint = get_rest_url( null, '/wp/v2/statements?&tu_author=' . $val->term_id );
+				} );
+			}
+
+			$retval['authors'] = $authors;
+
+			return new WP_REST_Response( $retval, 200 );
+		}
 	}
+}
+
+
+/**
+ * Adds support for custom "text" format for `get_archives_link()`.
+ *
+ * @since 1.1.0
+ * @author Jo Dickson
+ * @param string $link_html The archive HTML link content.
+ * @param string $url       URL to archive.
+ * @param string $text      Archive text description.
+ * @param string $format    Link format. Can be 'link', 'option', 'html', or custom.
+ * @param string $before    Content to prepend to the description.
+ * @param string $after     Content to append to the description.
+ * @return string Modified HTML link content
+ */
+function tu_get_archives_link( $link_html, $url, $text, $format, $before, $after ) {
+	if ( $format === 'text' ) {
+		$link_html = $before . $text . $after;
+	}
+	return $link_html;
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Adds a new REST endpoint, `/ucf-news/v1/statement-archives/`, that lists grouped links to vanilla Statement endpoints, filtered by year and author.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Will be necessary for digesting and displaying Statements on the main site.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
