### PR TITLE
Disabled archives for author tax, statement cpt

### DIFF
--- a/includes/today-post-types.php
+++ b/includes/today-post-types.php
@@ -119,7 +119,7 @@ if ( ! class_exists( 'UCF_Statement_PostType' ) ) {
 				'show_in_admin_bar'   => true,
 				'show_in_nav_menus'   => true,
 				'can_export'          => true,
-				'has_archive'         => true,
+				'has_archive'         => false,
 				'rewrite'             => array( 'slug' => $plural_lower ),
 				'delete_with_user'    => false,
 				'exclude_from_search' => false,

--- a/includes/today-taxonomies.php
+++ b/includes/today-taxonomies.php
@@ -89,7 +89,7 @@ if ( ! class_exists( 'UCF_Authors_Taxonomy' ) ) {
 			$args = array(
 				'labels'                     => self::labels( $labels ),
 				'hierarchical'               => false,
-				'public'                     => true,
+				'public'                     => false,
 				'show_ui'                    => true,
 				'show_in_quick_edit'         => false,
 				'meta_box_cb'                => false, // Define custom ACF field for managing these instead


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Disabled archives for the Statement post type.  We'll redirect /news/statements/ to /statements/ on the main site via Redirection.
- Made Author terms completely unavailable on the site frontend (no archives, no single term view)

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
We don't want either of these object types to have archives, and we don't want/need a single term view for authors.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
