### PR TITLE
Modified orderby/order for ACF post select2 queries

### DIFF
--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -146,7 +146,7 @@
                 "label": "Email Content",
                 "name": "gmucf_email_content",
                 "type": "flexible_content",
-                "instructions": "Select and order the email content.\r\n<br><br>\r\nSelect <strong>at least<\/strong> one Top Story and one Featured Stories Row. Each Featured Stories Row must have two featured stories selected; one in each column.\r\n<br><br>\r\nSpotlights can be added but are not required. There is a maximum of 2 spotlights per email.\r\n<br><br>\r\nPhoto sets can be selected from either the Top Story or Featured Stories options.",
+                "instructions": "Select and order the email content.\r\n<br><br>\r\nSelect <strong>at least<\/strong> one Top Story and one Featured Stories Row. Each Featured Stories Row must have two featured stories selected; one in each column.\r\n<br><br>\r\nSpotlights can be added but are not required. There is a maximum of 2 spotlights per email.\r\n",
                 "required": 0,
                 "conditional_logic": 0,
                 "wrapper": {

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -175,8 +175,7 @@
                                     "id": ""
                                 },
                                 "post_type": [
-                                    "post",
-                                    "photoset"
+                                    "post"
                                 ],
                                 "taxonomy": [],
                                 "allow_null": 0,
@@ -285,8 +284,7 @@
                                             "id": ""
                                         },
                                         "post_type": [
-                                            "post",
-                                            "photoset"
+                                            "post"
                                         ],
                                         "taxonomy": [],
                                         "allow_null": 0,
@@ -387,8 +385,7 @@
                                             "id": ""
                                         },
                                         "post_type": [
-                                            "post",
-                                            "photoset"
+                                            "post"
                                         ],
                                         "taxonomy": [],
                                         "allow_null": 0,

--- a/includes/today-utilities-admin.php
+++ b/includes/today-utilities-admin.php
@@ -230,7 +230,7 @@ add_filter( 'oembed_remote_get_args', 'tu_oembed_timeout' );
 /**
  * Modifies query args for ACF Select2 post field ajax lookups
  *
- * @since 1.1.0
+ * @since 1.0.12
  * @author Jo Dickson
  * @param array $args WP Query args
  * @param array $field Field data

--- a/includes/today-utilities-admin.php
+++ b/includes/today-utilities-admin.php
@@ -225,3 +225,24 @@ function tu_oembed_timeout( $args ) {
 }
 
 add_filter( 'oembed_remote_get_args', 'tu_oembed_timeout' );
+
+
+/**
+ * Modifies query args for ACF Select2 post field ajax lookups
+ *
+ * @since 1.1.0
+ * @author Jo Dickson
+ * @param array $args WP Query args
+ * @param array $field Field data
+ * @param int $post_id Post ID
+ * @return array Modified WP Query args
+ */
+function tu_acf_post_field_query( $args, $field, $post_id ) {
+	if ( count( $field['post_type'] ) === 1 && $field['post_type'][0] === 'post' ) {
+		$args['orderby'] = 'modified date';
+		$args['order']   = 'DESC';
+	}
+	return $args;
+}
+
+add_filter( 'acf/fields/post_object/query', 'tu_acf_post_field_query', 10, 3 );


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added a filter for the `acf/fields/post_object/query` filter hook to modify the orderby/order rules of fetched posts in ACF post select inputs.  By default, posts are sorted by post title; this change sorts them by last modified/published date.

Also removes some references to a now-nonexistent 'photoset' post type in the ACF config.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To make it easier for content editors to find recently edited/published posts when building out the homepage, GMUCF news email, or custom main site news feeds.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
