### PR TITLE
Hide statements admin menu for users without admin level capabilities

### DIFF
--- a/includes/today-post-types.php
+++ b/includes/today-post-types.php
@@ -86,9 +86,9 @@ if ( ! class_exists( 'UCF_Statement_PostType' ) ) {
 		* @since 1.0.0
 		* @param array $labels The labels array
 		* 						Defaults:
-		* 							( 'singular'    => 'Location' ),
-		* 							( 'plural'      => 'Locations' ),
-		* 							( 'text_domain' => 'ucf_location' )
+		* 							( 'singular'    => 'Statement' ),
+		* 							( 'plural'      => 'Statements' ),
+		* 							( 'text_domain' => 'ucf_statement' )
 		* @return array
 		*/
 		public static function registration_args( $labels ) {

--- a/includes/today-utilities-admin.php
+++ b/includes/today-utilities-admin.php
@@ -391,3 +391,24 @@ function tu_acf_post_field_query( $args, $field, $post_id ) {
 }
 
 add_filter( 'acf/fields/post_object/query', 'tu_acf_post_field_query', 10, 3 );
+
+
+/**
+ * Adjusts available menu items in the WordPress admin.
+ *
+ * (Temporarily) removes access to the Statements post type
+ * editing tools for users with admin-level capabilities.
+ *
+ * @since 1.1.0
+ * @author Jo Dickson
+ * @return void
+ */
+function tu_manage_menus() {
+	// Assume that if a user can manage options, they should
+	// be able to create/edit Statements (admin +)
+	if ( ! current_user_can( 'manage_options' ) ) {
+		remove_menu_page( 'edit.php?post_type=ucf_statement' );
+	}
+}
+
+add_action( 'admin_menu', 'tu_manage_menus' );

--- a/includes/today-utilities-admin.php
+++ b/includes/today-utilities-admin.php
@@ -397,7 +397,7 @@ add_filter( 'acf/fields/post_object/query', 'tu_acf_post_field_query', 10, 3 );
  * Adjusts available menu items in the WordPress admin.
  *
  * (Temporarily) removes access to the Statements post type
- * editing tools for users with admin-level capabilities.
+ * editing tools for users without admin-level capabilities.
  *
  * @since 1.1.0
  * @author Jo Dickson


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
See title.  Note that you can still technically access Statement editing tools if you access the correct admin URLs manually, but for our purposes of deploying v1.1.0, this should be a suitable solution.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Restricted access to the Statements post type was requested by Roger.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Verified in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
