### PR TITLE
Added embed flush command

### DIFF
--- a/includes/today-wpcli.php
+++ b/includes/today-wpcli.php
@@ -1,0 +1,86 @@
+<?php
+/**
+ * Various commands for managing Today posts and their data
+ */
+
+class Today_Embed_Commands extends WP_CLI_Command {
+	/**
+	 * Removes cache data from the database for embeds that
+	 * did not return a successful response.
+	 *
+	 * ## EXAMPLES
+	 *
+	 * $ wp today embeds flush
+	 *
+	 * @when after_wp_load
+	 */
+	public function flush( $args ) {
+		global $wpdb;
+
+		// Retrieve embed hashes and their corresponding post IDs
+		// for embeds with bad cache data.
+		//
+		// NOTE: hashes should be mapped to their corresponding
+		// post IDs, and not assumed to be completely unique on their
+		// own; identical hashes with valid embed data could exist for
+		// other posts.
+		$rows = $wpdb->get_results( $wpdb->prepare(
+			"SELECT DISTINCT
+			SUBSTR(meta_key, -32) AS embed_hash,
+			post_id
+			FROM $wpdb->postmeta
+			WHERE meta_key LIKE '_oembed_%%'
+			AND meta_key NOT LIKE '_oembed_time_%%'
+			AND meta_value = %s",
+			array(
+				'{{unknown}}'
+			)
+		) ) ?: array();
+
+		$result_count = count( $rows );
+		$success_count = 0;
+
+		// Perform a DELETE for each row of retrieved data that clears
+		// corresponding _oembed_HASH and _oembed_time_HASH metadata:
+		if ( $rows ) {
+			foreach ( $rows as $row ) {
+				$has_error = false;
+
+				try {
+					$post_id            = intval( $row->post_id );
+					$embed_key          = "_oembed_$row->embed_hash";
+					$embed_time_key     = "_oembed_time_$row->embed_hash";
+
+					// Delete both the embed data itself, and its cache
+					// time data.
+					//
+					// We only care about whether or not the actual embed
+					// meta got deleted or not; the embed time data may or
+					// may not exist, so we don't check if it actually got
+					// deleted during this step:
+					$embed_deleted      = delete_post_meta( $post_id, $embed_key );
+					$embed_time_deleted = delete_post_meta( $post_id, $embed_time_key );
+
+					if ( ! $embed_deleted ) {
+						$has_error = true;
+						WP_CLI::warning( "Could not delete metadata for post with ID $post_id, meta key $embed_key" );
+					}
+
+					if ( ! $has_error ) {
+						$success_count++;
+					}
+				}
+				catch ( Exception $e ) {
+					WP_CLI::error( $e->getMessage(), $e->getCode() );
+				}
+			}
+		}
+
+		WP_CLI::success( "Finished processing $result_count instances of embed cache data." );
+		if ( ! $result_count ) {
+			WP_CLI::success( "No instances of bad embed cache data were found." );
+		} else {
+			WP_CLI::success( "Successfully removed $success_count instances of bad embed cache data." );
+		}
+	}
+}

--- a/today-utilities.php
+++ b/today-utilities.php
@@ -30,6 +30,13 @@ require_once TU_PLUGIN_DIR . 'includes/today-revisions.php';
 require_once TU_PLUGIN_DIR . 'api/today-custom-post-api.php';
 
 
+if ( defined( 'WP_CLI' ) && WP_CLI ) {
+	require_once TU_PLUGIN_DIR . 'includes/today-wpcli.php';
+
+	WP_CLI::add_command( 'today embeds', 'Today_Embed_Commands' );
+}
+
+
 /**
  * Function that runs on plugin activation
  *


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
Added a new wp-cli command, `wp today embeds flush`, which removes all bad oEmbed metadata associated with posts (failed responses for oEmbeds).

More specifically, we look for `_oembed_HASH` meta whose value is "{{undefined}}", a value WP assigns when oEmbed retrieval fails, and delete said meta and its associated `_oembed_time_HASH` meta.  Existing oEmbed metadata for successful responses is unaffected.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
To give us more flexibility and control over the removal of this metadata, and to provide the opportunity for failed embeds to be re-fetched.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Tested in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
