### PR TITLE
Main site options admin page updates

### DIFF
--- a/api/today-custom-post-api.php
+++ b/api/today-custom-post-api.php
@@ -307,11 +307,10 @@ if ( ! class_exists( 'UCF_Today_Custom_API' ) ) {
 		 * @return WP_REST_Response
 		 */
 		public static function get_mainsite_header_story( $request ) {
-
-			$stories = get_fields( 'main_site_news_feed' );
-			$post = $stories['edu_header_story_options']['main_site_header_story'];
-			$title_override = $stories['edu_header_story_options']['main_site_header_story_title_override'];
-			$subtitle_override = $stories['edu_header_story_options']['main_site_header_story_subtitle_override'];
+			$options = get_fields( 'main_site_news_feed' );
+			$post = $options['main_site_header_story'];
+			$title_override = $options['main_site_header_story_title_override'];
+			$subtitle_override = $options['main_site_header_story_subtitle_override'];
 
 			if( $post ) :
 

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -1,7 +1,7 @@
 [
     {
         "key": "group_5c9cddeea9e45",
-        "title": "EDU News Options",
+        "title": "Main Site News Feed Options",
         "fields": [
             {
                 "key": "field_5c9e37641bcbe",

--- a/dev/acf-export.json
+++ b/dev/acf-export.json
@@ -4,191 +4,83 @@
         "title": "EDU News Options",
         "fields": [
             {
-                "key": "field_6047f08d0dce6",
-                "label": "EDU Stories Feed Options",
-                "name": "edu_stories_feed_options",
-                "type": "group",
-                "instructions": "",
-                "required": 0,
+                "key": "field_5c9e37641bcbe",
+                "label": "Feed Mode",
+                "name": "main_site_stories_feed_config",
+                "type": "radio",
+                "instructions": "Choose which feed should be used.",
+                "required": 1,
                 "conditional_logic": 0,
                 "wrapper": {
                     "width": "",
                     "class": "",
                     "id": ""
                 },
-                "layout": "block",
-                "sub_fields": [
-                    {
-                        "key": "field_5c9e37641bcbe",
-                        "label": "Feed Mode",
-                        "name": "main_site_stories_feed_config",
-                        "type": "radio",
-                        "instructions": "Choose which feed should be used.",
-                        "required": 1,
-                        "conditional_logic": 0,
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "choices": {
-                            "default": "Display the most recent stories with \"Promote on Main Site\" field set to true.",
-                            "custom": "Display a custom set of stories."
-                        },
-                        "allow_null": 0,
-                        "other_choice": 0,
-                        "default_value": "default",
-                        "layout": "vertical",
-                        "return_format": "value",
-                        "save_other_choice": 0
-                    },
-                    {
-                        "key": "field_5c9e2f1d9c2c5",
-                        "label": "Feed Expiration",
-                        "name": "main_site_stories_expire",
-                        "type": "date_picker",
-                        "instructions": "Choose when the custom feed should expire.",
-                        "required": 1,
-                        "conditional_logic": [
-                            [
-                                {
-                                    "field": "field_5c9e37641bcbe",
-                                    "operator": "==",
-                                    "value": "custom"
-                                }
-                            ]
-                        ],
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "display_format": "F j, Y",
-                        "return_format": "m\/d\/Y",
-                        "first_day": 0
-                    },
-                    {
-                        "key": "field_5c9cddf6a827b",
-                        "label": "Stories",
-                        "name": "main_site_stories",
-                        "type": "post_object",
-                        "instructions": "Add stories to be displayed on www.ucf.edu.",
-                        "required": 1,
-                        "conditional_logic": [
-                            [
-                                {
-                                    "field": "field_5c9e37641bcbe",
-                                    "operator": "==",
-                                    "value": "custom"
-                                }
-                            ]
-                        ],
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "post_type": [
-                            "post"
-                        ],
-                        "taxonomy": "",
-                        "allow_null": 0,
-                        "multiple": 1,
-                        "return_format": "id",
-                        "ui": 1
-                    }
-                ]
+                "choices": {
+                    "default": "Display the most recent stories with \"Promote on Main Site\" field set to true.",
+                    "custom": "Display a custom set of stories."
+                },
+                "allow_null": 0,
+                "other_choice": 0,
+                "default_value": "default",
+                "layout": "vertical",
+                "return_format": "value",
+                "save_other_choice": 0
             },
             {
-                "key": "field_6047f02c1aab3",
-                "label": "EDU Header Story Options",
-                "name": "edu_header_story_options",
-                "type": "group",
-                "instructions": "",
-                "required": 0,
-                "conditional_logic": 0,
+                "key": "field_5c9e2f1d9c2c5",
+                "label": "Feed Expiration",
+                "name": "main_site_stories_expire",
+                "type": "date_picker",
+                "instructions": "Choose when the custom feed should expire.",
+                "required": 1,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5c9e37641bcbe",
+                            "operator": "==",
+                            "value": "custom"
+                        }
+                    ]
+                ],
                 "wrapper": {
                     "width": "",
                     "class": "",
                     "id": ""
                 },
-                "layout": "block",
-                "sub_fields": [
-                    {
-                        "key": "field_60413825e0ada",
-                        "label": "Header Story",
-                        "name": "main_site_header_story",
-                        "type": "post_object",
-                        "instructions": "The story to display in the header on UCF.edu (if the custom layout is active)",
-                        "required": 0,
-                        "conditional_logic": 0,
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "post_type": [
-                            "post"
-                        ],
-                        "taxonomy": "",
-                        "allow_null": 1,
-                        "multiple": 0,
-                        "return_format": "object",
-                        "ui": 1
-                    },
-                    {
-                        "key": "field_60413bfa7e88b",
-                        "label": "Header Story Title Override",
-                        "name": "main_site_header_story_title_override",
-                        "type": "text",
-                        "instructions": "The story title will be displayed if left blank.",
-                        "required": 0,
-                        "conditional_logic": [
-                            [
-                                {
-                                    "field": "field_60413825e0ada",
-                                    "operator": "!=empty"
-                                }
-                            ]
-                        ],
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "default_value": "",
-                        "placeholder": "",
-                        "prepend": "",
-                        "append": "",
-                        "maxlength": ""
-                    },
-                    {
-                        "key": "field_60413cde7e88c",
-                        "label": "Header Story Subtitle Override",
-                        "name": "main_site_header_story_subtitle_override",
-                        "type": "text",
-                        "instructions": "The story subtitle will be displayed if left blank.",
-                        "required": 0,
-                        "conditional_logic": [
-                            [
-                                {
-                                    "field": "field_60413825e0ada",
-                                    "operator": "!=empty"
-                                }
-                            ]
-                        ],
-                        "wrapper": {
-                            "width": "",
-                            "class": "",
-                            "id": ""
-                        },
-                        "default_value": "",
-                        "placeholder": "",
-                        "prepend": "",
-                        "append": "",
-                        "maxlength": ""
-                    }
-                ]
+                "display_format": "F j, Y",
+                "return_format": "m\/d\/Y",
+                "first_day": 0
+            },
+            {
+                "key": "field_5c9cddf6a827b",
+                "label": "Stories",
+                "name": "main_site_stories",
+                "type": "post_object",
+                "instructions": "Add stories to be displayed on www.ucf.edu.",
+                "required": 1,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_5c9e37641bcbe",
+                            "operator": "==",
+                            "value": "custom"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "post_type": [
+                    "post"
+                ],
+                "taxonomy": "",
+                "allow_null": 0,
+                "multiple": 1,
+                "return_format": "id",
+                "ui": 1
             }
         ],
         "location": [
@@ -678,6 +570,103 @@
         "menu_order": 0,
         "position": "normal",
         "style": "seamless",
+        "label_placement": "top",
+        "instruction_placement": "label",
+        "hide_on_screen": "",
+        "active": true,
+        "description": ""
+    },
+    {
+        "key": "group_6054bc3d887d7",
+        "title": "Main Site Header Story Options",
+        "fields": [
+            {
+                "key": "field_60413825e0ada",
+                "label": "Header Story",
+                "name": "main_site_header_story",
+                "type": "post_object",
+                "instructions": "The story to display in the header on UCF.edu (if the custom layout is active)",
+                "required": 0,
+                "conditional_logic": 0,
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "post_type": [
+                    "post"
+                ],
+                "taxonomy": "",
+                "allow_null": 1,
+                "multiple": 0,
+                "return_format": "object",
+                "ui": 1
+            },
+            {
+                "key": "field_60413bfa7e88b",
+                "label": "Header Story Title Override",
+                "name": "main_site_header_story_title_override",
+                "type": "text",
+                "instructions": "The story title will be displayed if left blank.",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_60413825e0ada",
+                            "operator": "!=empty"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            },
+            {
+                "key": "field_60413cde7e88c",
+                "label": "Header Story Subtitle Override",
+                "name": "main_site_header_story_subtitle_override",
+                "type": "text",
+                "instructions": "The story subtitle will be displayed if left blank.",
+                "required": 0,
+                "conditional_logic": [
+                    [
+                        {
+                            "field": "field_60413825e0ada",
+                            "operator": "!=empty"
+                        }
+                    ]
+                ],
+                "wrapper": {
+                    "width": "",
+                    "class": "",
+                    "id": ""
+                },
+                "default_value": "",
+                "placeholder": "",
+                "prepend": "",
+                "append": "",
+                "maxlength": ""
+            }
+        ],
+        "location": [
+            [
+                {
+                    "param": "options_page",
+                    "operator": "==",
+                    "value": "main-site-news-feed"
+                }
+            ]
+        ],
+        "menu_order": 0,
+        "position": "normal",
+        "style": "default",
         "label_placement": "top",
         "instruction_placement": "label",
         "hide_on_screen": "",

--- a/includes/today-options-main-site-feed.php
+++ b/includes/today-options-main-site-feed.php
@@ -1,19 +1,19 @@
 <?php
 /**
  * Functions for adding and supporting the
- * Main Site News Feed Options Page
+ * Main Site Options Page
  */
 function tu_add_main_site_feed_options_page() {
 	if ( function_exists( 'acf_add_options_page' ) ) {
 		acf_add_options_page( array(
-			'page_title' 	  => 'Main Site News Feed',
+			'page_title' 	  => 'Main Site Options',
 			'post_id'         => 'main_site_news_feed',
-			'menu_title'	  => 'EDU News Feed',
+			'menu_title'	  => 'Main Site Options',
 			'menu_slug' 	  => 'main-site-news-feed',
 			'capability'	  => 'administrator',
 			'icon_url'        => 'dashicons-images-alt2',
 			'redirect'        => false,
-			'updated_message' => 'Main Site News Feed Updated'
+			'updated_message' => 'Main site options updated'
 		) );
 	}
 }


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
<!--- Describe your changes in detail -->
- Updated the name of the main site options page from "EDU News Feed" to "Main Site Options"
- Splits the news feed options and header story options into two separate field groups (metaboxes) instead of using group fields.  This change reverts #48.

**Motivation and Context**
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
- Options page name update requested by Roger.
- Using separate field groups (metaboxes) vs group fields for the sets of options ensures the main site news feed endpoint continues to pull field values as expected.  After the move to group fields, the main site stories endpoint would've needed updating to ensure fetched field names were prefixed with the group slug, like what was done in #48.  Using separate field groups and reverting #48 resolves this.

**How Has This Been Tested?**
<!--- Please describe how you tested your changes. -->
Reviewed in Dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
