### PR TITLE
Added post_tag to resource links

### DIFF
--- a/includes/today-resource-link-overrides.php
+++ b/includes/today-resource-link-overrides.php
@@ -1,0 +1,23 @@
+<?php
+/**
+ * Hooks for modifying the ucf_resource_link post type
+ */
+
+/**
+ * Adds post_tag to the ucf_resource_link
+ * taxonomy array.
+ * @author Jim Barnes
+ * @since 1.4.0
+ * 
+ * @param array $taxonomies The array of incoming taxonomies.
+ * @return array The modified taxonomies array.
+ */
+function tu_resource_link_taxonomies( $taxonomies ) {
+    if ( ! in_array( 'post_tag', $taxonomies ) ) {
+        $taxonomies[] = 'post_tag';
+    }
+
+    return $taxonomies;
+}
+
+add_filter( 'resource_link_taxonomies', 'tu_resource_link_taxonomies', 10, 1 );

--- a/today-utilities.php
+++ b/today-utilities.php
@@ -26,6 +26,7 @@ require_once TU_PLUGIN_DIR . 'includes/today-options-gmucf.php';
 require_once TU_PLUGIN_DIR . 'includes/today-options-main-site-feed.php';
 require_once TU_PLUGIN_DIR . 'includes/today-feeds.php';
 require_once TU_PLUGIN_DIR . 'includes/today-revisions.php';
+require_once TU_PLUGIN_DIR . 'includes/today-resource-link-overrides.php';
 
 require_once TU_PLUGIN_DIR . 'api/today-custom-post-api.php';
 


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Adds the `post_tag` taxonomies to the `ucf_resource_link` post type for the UCF Today website.

Note: Registering a filter only places that filter within a queue. If, for whatever reason, the `ucf_resource_link` post type doesn't exist - i.e. the plugin is not activated - then this filter will never be called. Therefore, an additional check to see if the plugin exists and is activated is unnecessary.

**Motivation and Context**
We want to be able to tag external stories and then use those tags to show specific stories on tag pages.

**How Has This Been Tested?**
Changes have been tested locally and will be further tested upon deployment to pantheon.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
