### PR TITLE
Added cache clearing logic to news email builder

### DIFF
--- a/includes/today-options-gmucf.php
+++ b/includes/today-options-gmucf.php
@@ -457,3 +457,22 @@ function tu_load_announcement_choices( $field ) {
 }
 
 add_filter( 'acf/load_field/name=gmucf_announcements', 'tu_load_announcement_choices' );
+
+if ( function_exists( 'pantheon_clear_edge_paths' ) ) {
+	function tu_on_options_page_save( $post_id, $menu_slug ) {
+		if ( $post_id === 'gmucf_announcements' ) {
+			pantheon_clear_edge_paths(
+				[
+					'/news/',
+					'/news/mail/',
+					'/gmucf/news/',
+					'/gmucf/news/mail/',
+					'/news/wp-json/ucf-news/v1/gmucf-email-options/',
+					'/news/wp-json/ucf-news/v1/external-stories/'
+				]
+			);
+		}
+	}
+
+	add_action( 'acf/options_page/save', 'tu_on_options_page_save', 10, 2 );
+}


### PR DESCRIPTION
<!---
Thank you for contributing to Today-Utilities.

Please make sure you've read our contributing guidelines:
https://github.com/UCF/Today-Utilities/blob/master/CONTRIBUTING.md

Provide a general summary of your changes in the Title above and fill in the template below.
-->

**Description**
Added cache clearing logic to news email builder.

**Motivation and Context**
We want to make sure the cache clears in Pantheon whenever the news email builder is updated.

**How Has This Been Tested?**
It hasn't. It will be tested when we deploy it to dev.

**Types of changes**
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

**Checklist:**
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [ ] My change requires an update to the documentation.
- [ ] I have updated the documentation accordingly.
